### PR TITLE
mask the dbc id

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -808,7 +808,8 @@ fn message(s: &str) -> IResult<&str, Message> {
     let (s, _) = multispace0(s)?;
     let (s, _) = tag("BO_")(s)?;
     let (s, _) = ms1(s)?;
-    let (s, message_id) = message_id(s)?;
+    let (s, MessageId(message_id)) = message_id(s)?;
+    let message_id = MessageId(message_id & 0x1FFFFFFF);
     let (s, _) = ms1(s)?;
     let (s, message_name) = c_ident(s)?;
     let (s, _) = colon(s)?;


### PR DESCRIPTION
hi, thanks for the work so far. 

for extended 29-bit CAN IDs a [mask](https://www.csselectronics.com/pages/can-dbc-file-database-intro) needs to be applied.