### PR TITLE
Deduplicate Value Names

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1575,23 +1575,25 @@ fn signal_groups(s: &str) -> IResult<&str, SignalGroups> {
 fn deduplicate_value_description_names(
     mut value_descriptions: Vec<ValueDescription>,
 ) -> Vec<ValueDescription> {
-    let mut name_count = HashMap::<String, i32>::new();
-
     for desc in &mut value_descriptions {
         if let ValueDescription::Signal {
             message_id: _,
-            signal_name,
-            value_descriptions: _,
+            signal_name: _,
+            value_descriptions,
         } = desc
         {
-            let count_entry = name_count.entry(signal_name.clone()).or_default();
-            *count_entry += 1;
+            let mut name_count = HashMap::<String, i32>::new();
 
-            if *count_entry > 1 {
-                let mut old_name = String::new();
-                std::mem::swap(signal_name, &mut old_name);
+            for val_desc in value_descriptions {
+                let count_entry = name_count.entry(val_desc.b.clone()).or_default();
+                *count_entry += 1;
 
-                *signal_name = format!("{old_name}{count_entry}")
+                if *count_entry > 1 {
+                    let mut old_name = String::new();
+                    std::mem::swap(&mut val_desc.b, &mut old_name);
+
+                    val_desc.b = format!("{old_name}{count_entry}")
+                }
             }
         }
     }


### PR DESCRIPTION
Hi!

I have a dbc with this line in it:

VAL_ 123456 Name 14 "Error" 0 "Normal" 1 "Low" 2 "Too low" 3 "High" 4 "Reserved" 5 "Reserved" 6 "Reserved" 15 "Not Available" ;

That generated this code with dbc-codegen:
```Rust
#[derive(Clone, Copy, PartialEq)]
#[derive(Debug)]
pub enum Name {
    Error,
    Normal,
    Low,
    TooLow,
    High,
    Reserved,
    Reserved,
    Reserved,
    NotAvailable,
    _Other(u8),
}
```

Which is not valid rust. With this pr the generated code instead becomes:

```Rust
#[derive(Clone, Copy, PartialEq)]
#[derive(Debug)]
pub enum Name {
    Error,
    Normal,
    Low,
    TooLow,
    High,
    Reserved,
    Reserved2,
    Reserved3,
    NotAvailable,
    _Other(u8),
}
```

