### PR TITLE
Add support for escaped quotation marks within comments

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -628,10 +628,6 @@ fn is_c_ident_head(chr: char) -> bool {
     chr.is_alphabetic() || chr == '_'
 }
 
-fn is_quote(chr: char) -> bool {
-    chr == '"'
-}
-
 fn is_quote_or_escape_character(chr: char) -> bool {
     chr == '"' || chr == '\\'
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -171,13 +171,13 @@ mod tests {
     }
 
     #[test]
-    fn signal_comment_with_escaped_quotation_marks_test() {
-        let def1 = "CM_ SG_ 2147548912 EngPTOAccelerateSwitch \"Switch signal of the PTO control activator which indicates that the activator is in the position \\\"accelerate\\\".\";\n";
+    fn signal_comment_with_escaped_characters_test() {
+        let def1 = "CM_ SG_ 2147548912 FooBar \"Foo\\\\ \\n \\\"Bar\\\"\";\n";
         let message_id = MessageId::Extended(65264);
         let comment1 = Comment::Signal {
             message_id,
-            signal_name: "EngPTOAccelerateSwitch".to_string(),
-            comment: "Switch signal of the PTO control activator which indicates that the activator is in the position \\\"accelerate\\\".".to_string(),
+            signal_name: "FooBar".to_string(),
+            comment: "Foo\\\\ \\n \\\"Bar\\\"".to_string(),
         };
         let (_, comment1_def) = comment(def1).expect("Failed to parse signal comment definition");
         assert_eq!(comment1, comment1_def);
@@ -185,11 +185,11 @@ mod tests {
 
     #[test]
     fn empty_signal_comment_test() {
-        let def1 = "CM_ SG_ 2147548912 EngPTOAccelerateSwitch \"\";\n";
+        let def1 = "CM_ SG_ 2147548912 FooBar \"\";\n";
         let message_id = MessageId::Extended(65264);
         let comment1 = Comment::Signal {
             message_id,
-            signal_name: "EngPTOAccelerateSwitch".to_string(),
+            signal_name: "FooBar".to_string(),
             comment: "".to_string(),
         };
         let (_, comment1_def) = comment(def1).expect("Failed to parse signal comment definition");


### PR DESCRIPTION
Consider the following signal declaration:
```
CM_ SG_ 2147548912 Foobar "Foo \"bar\"";
```

It has the word "bar" in quotation marks inside the comment string.
The current version of can-dbc fails to parse this.

This PR fixes this issue so that the comment gets parsed as `Foo \"bar\"` (_including_ the escape characters themselves!).

The fix is small, and unittests are included, so should hopefully be easy to accept. :)