### PR TITLE
chore: bump dependencies and minor cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,14 @@ homepage = "https://github.com/marcelbuesing/can-dbc"
 repository = "https://github.com/marcelbuesing/can-dbc.git"
 authors = ["marcelbuesing <buesing.marcel@googlemail.com>"]
 keywords = ["dbc", "can", "automotive", "ecu"]
-edition = "2018"
+edition = "2021"
 
 [badges]
 travis-ci = { repository = "marcelbuesing/can-dbc", branch = "dev" }
 codecov = { repository = "marcelbuesing/can-dbc", branch = "dev", service = "github" }
 
 [dependencies]
-derive-getters = "0.3"
+derive-getters = "0.5"
 nom = { version = "7.1", features = ["alloc"] }
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }

--- a/examples/file_parser.rs
+++ b/examples/file_parser.rs
@@ -29,13 +29,13 @@ fn main() -> io::Result<()> {
     let dbc_in = std::str::from_utf8(&buffer).unwrap();
 
     match can_dbc::DBC::try_from(dbc_in) {
-        Ok(dbc_content) => println!("DBC Content{:#?}", dbc_content),
+        Ok(dbc_content) => println!("DBC Content{dbc_content:#?}"),
         Err(e) => {
             match e {
-                can_dbc::Error::Nom(nom::Err::Error(e)) => eprintln!("{:?}", e),
-                can_dbc::Error::Nom(nom::Err::Failure(e)) => eprintln!("{:?}", e),
-                can_dbc::Error::Nom(nom::Err::Incomplete(needed)) => eprintln!("Nom incomplete needed: {:#?}", needed),
-                can_dbc::Error::Incomplete(dbc, remaining) => eprintln!("Not all data in buffer was read {:#?}, remaining unparsed (length: {}): {}\n...(truncated)", dbc, remaining.len(), remaining),
+                can_dbc::Error::Nom(nom::Err::Error(e)) => eprintln!("{e:?}"),
+                can_dbc::Error::Nom(nom::Err::Failure(e)) => eprintln!("{e:?}"),
+                can_dbc::Error::Nom(nom::Err::Incomplete(needed)) => eprintln!("Nom incomplete needed: {needed:#?}"),
+                can_dbc::Error::Incomplete(dbc, remaining) => eprintln!("Not all data in buffer was read {dbc:#?}, remaining unparsed (length: {}): {remaining}\n...(truncated)", remaining.len()),
                 can_dbc::Error::MultipleMultiplexors => eprintln!("Multiple multiplexors defined"),
             }
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -190,7 +190,7 @@ mod tests {
         let comment1 = Comment::Signal {
             message_id,
             signal_name: "FooBar".to_string(),
-            comment: "".to_string(),
+            comment: String::new(),
         };
         let (_, comment1_def) = comment(def1).expect("Failed to parse signal comment definition");
         assert_eq!(comment1, comment1_def);
@@ -603,16 +603,16 @@ mod tests {
 
     #[test]
     fn extended_message_id_test() {
-        let s = (0x1FFFFFFFu32 | 1 << 31).to_string();
+        let s = (0x1FFF_FFFF_u32 | 1 << 31).to_string();
         let (_, extended_message_id) = message_id(&s).unwrap();
-        assert_eq!(extended_message_id, MessageId::Extended(0x1FFFFFFF));
+        assert_eq!(extended_message_id, MessageId::Extended(0x1FFF_FFFF));
     }
 
     #[test]
     fn extended_message_id_test_max_29bit() {
         let s = u32::MAX.to_string();
         let (_, extended_message_id) = message_id(&s).unwrap();
-        assert_eq!(extended_message_id, MessageId::Extended(0x1FFFFFFF));
+        assert_eq!(extended_message_id, MessageId::Extended(0x1FFF_FFFF));
     }
 }
 
@@ -746,7 +746,7 @@ fn message_id(s: &str) -> IResult<&str, MessageId> {
     let (s, parsed_value) = complete::u32(s)?;
 
     if parsed_value & (1 << 31) != 0 {
-        Ok((s, MessageId::Extended(parsed_value & 0x1FFFFFFF)))
+        Ok((s, MessageId::Extended(parsed_value & 0x1FFF_FFFF)))
     } else {
         Ok((s, MessageId::Standard(parsed_value as u16)))
     }

--- a/tests/cantool-dbcs.rs
+++ b/tests/cantool-dbcs.rs
@@ -44,9 +44,9 @@ fn main() -> io::Result<()> {
         .collect::<Result<Vec<_>, io::Error>>()?;
 
     for dbc_path in entries {
-        println!("Next: {:?}", dbc_path);
+        println!("Next: {dbc_path:?}");
         if ignored_entries.contains(&dbc_path) {
-            println!("Ignoring: {:?}", dbc_path);
+            println!("Ignoring: {dbc_path:?}");
             continue;
         }
 


### PR DESCRIPTION
* Upgraded to 2021 edition - many dependencies are 2021 anyway
* `derive-getters` 0.3->0.5
* fix a few `cargo clippy` suggestions