### PR TITLE
chore: run `cargo fmt`

### DIFF
--- a/examples/file_parser.rs
+++ b/examples/file_parser.rs
@@ -1,12 +1,11 @@
 extern crate clap;
 
-use can_dbc::{self};
-use clap::{command, Arg};
-
 use std::convert::TryFrom;
 use std::fs::File;
 use std::io;
 use std::io::prelude::*;
+
+use clap::{command, Arg};
 
 fn main() -> io::Result<()> {
     let matches = command!()

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,19 +4,16 @@
 
 use std::str;
 
-use nom::{
-    branch::{alt, permutation},
-    bytes::complete::{tag, take_till, take_while, take_while1},
-    character::complete::{self, char, line_ending, multispace0, space0, space1},
-    combinator::{map, opt, value},
-    error::{ErrorKind, ParseError},
-    multi::{many0, many_till, separated_list0},
-    number::complete::double,
-    sequence::preceded,
-    AsChar, IResult, InputTakeAtPosition,
-};
-use nom::bytes::complete::{escaped, take_till1};
-use nom::character::complete::one_of;
+use nom::branch::{alt, permutation};
+use nom::bytes::complete::{escaped, tag, take_till, take_till1, take_while, take_while1};
+use nom::character::complete::{self, char, line_ending, multispace0, one_of, space0, space1};
+use nom::combinator::{map, opt, value};
+use nom::error::{ErrorKind, ParseError};
+use nom::multi::{many0, many_till, separated_list0};
+use nom::number::complete::double;
+use nom::sequence::preceded;
+use nom::{AsChar, IResult, InputTakeAtPosition};
+
 use crate::{
     AccessNode, AccessType, AttributeDefault, AttributeDefinition, AttributeValue,
     AttributeValueForObject, AttributeValuedForObjectType, Baudrate, ByteOrder, Comment, EnvType,
@@ -723,7 +720,11 @@ fn c_ident_vec(s: &str) -> IResult<&str, Vec<String>> {
 
 fn char_string(s: &str) -> IResult<&str, &str> {
     let (s, _) = quote(s)?;
-    let (s, optional_char_string_value) =  opt(escaped(take_till1(is_quote_or_escape_character), '\\', one_of(r#""n\"#)))(s)?;
+    let (s, optional_char_string_value) = opt(escaped(
+        take_till1(is_quote_or_escape_character),
+        '\\',
+        one_of(r#""n\"#),
+    ))(s)?;
     let (s, _) = quote(s)?;
 
     let char_string_value = optional_char_string_value.unwrap_or("");

--- a/tests/cantool-dbcs.rs
+++ b/tests/cantool-dbcs.rs
@@ -1,10 +1,8 @@
+use std::collections::HashSet;
+use std::fs::{self, File};
 use std::io;
 use std::io::prelude::*;
-use std::{
-    collections::HashSet,
-    fs::{self, File},
-    path::PathBuf,
-};
+use std::path::PathBuf;
 
 // #[test]
 fn main() -> io::Result<()> {


### PR DESCRIPTION
I ran `cargo +nightly fmt --all -- --config imports_granularity=Module,group_imports=StdExternalCrate` to cleanup the `use` statements a bit to make them more consistent.